### PR TITLE
Removed which_code_server which breaks pre-started code-server

### DIFF
--- a/src/jupyter_code_server/__init__.py
+++ b/src/jupyter_code_server/__init__.py
@@ -36,8 +36,6 @@ def setup_code_server():
     if code_server_module:
         pre_start_hook(code_server_module)
 
-    which_code_server()
-
     proxy_config_dict = {
         "new_browser_window": True,
         "timeout": 30,


### PR DESCRIPTION
Removed unconditional call of `which_code_server()` which breaks the pre-started code-server functionality - code-server is searched even if the server is supposed to only be available via network port.