### PR TITLE
Disable password

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Running VSCode Web IDE code-server inside the Jupyter environment.
     - [Setting the working directory](#setting-the-working-directory)
     - [Using pre-started code-server](#using-pre-started-code-server)
     - [Enable/disable launcher](#enabledisable-launcher)
+    - [Disable password login](#disable-password-login)
     - [Loading code-server using Lmod](#loading-code-server-using-lmod)
 
 
@@ -65,6 +66,11 @@ By default code-server launcher is enabled and visible in JupyterLab. Option `JS
 may be set to any non-empty value to disable launcher. This is useful when e.g. certain users are not supposed
 to have code-server available in Jupyterhub as there is no easy way to disable loading of entire `jupyter-code-server`
 module for these users if module is for example built into Docker image.
+
+### Disable password login
+
+By default, code-server is started with password authentication enabled.
+To disable password login (e.g., for internal or trusted environments), set the environment variable `CODE_DISABLE_PASSWORD` to `true`.
 
 ### Loading code-server using Lmod
 

--- a/src/jupyter_code_server/__init__.py
+++ b/src/jupyter_code_server/__init__.py
@@ -78,12 +78,19 @@ def setup_code_server():
 
     command_arguments = [
         '--socket={unix_socket}',
-        '--auth=password',
         '--disable-update-check',
         '--disable-file-uploads',
         '--disable-file-downloads',
         '--ignore-last-opened'  # needed to set a specific working directory
     ]
+
+    disable_password = os.environ.get('CODE_DISABLE_PASSWORD', 'false').lower() in ('1', 'true', 'yes')
+
+    if disable_password:
+        command_arguments.append('--auth=none')
+    else:
+        command_arguments.append('--auth=password')
+
 
     full_command = [which_code_server()] + command_arguments + additional_arguments + ['--'] + [working_directory]
     proxy_config_dict.update({


### PR DESCRIPTION
First up i really like the extension that you made here.
Only problem my users are running in to is the password login for the code-server.
Most of the users here try to login with there own password for the jupyterhub that we have setup. Causing a lot of questions to the admin.

I've made a small addition to the code that allows the admin to set an environment variable `CODE_DISABLE_PASSWORD` that disables the code server authentication. Next to this i've updated the readme to reflect these changes. 
